### PR TITLE
splitting build scripts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -59,39 +59,3 @@ test -n "$SKIP_LIBWEBM" ||(
 echo "============================================="
 echo "Compiling libwebm done"
 echo "============================================="
-
-echo "============================================="
-echo "Compiling wasm bindings"
-echo "============================================="
-(
-  emcc \
-    ${OPTIMIZE} \
-    --bind \
-    -s STRICT=1 \
-    -s NO_DYNAMIC_EXECUTION=1 \
-    -s ALLOW_MEMORY_GROWTH=1 \
-    -s ASSERTIONS=0 \
-    -s MODULARIZE=1 \
-    -s FILESYSTEM=0 \
-    -s EXPORT_ES6=1 \
-    -s MALLOC=emmalloc \
-    --std=c++11 \
-    -I node_modules/libyuv/include \
-    -I node_modules/libvpx \
-    -I node_modules/libwebm \
-    -I build-vpx \
-    -I build-webm \
-    -o ./webm-wasm.js \
-    -x c++ \
-    src/webm-wasm.cpp \
-    src/mkvwriter/mymkvwriter.cpp \
-    src/mkvwriter/mymkvstreamwriter.cpp \
-    build-yuv/libyuv.a \
-    build-vpx/libvpx.a \
-    build-webm/libwebm.a
-  mkdir dist || true
-  mv webm-wasm.{js,wasm} dist
-)
-echo "============================================="
-echo "Compiling wasm bindings done"
-echo "============================================="

--- a/emcc.sh
+++ b/emcc.sh
@@ -1,0 +1,32 @@
+echo "============================================="
+echo "Compiling wasm bindings"
+echo "============================================="
+(
+  emcc \
+    ${OPTIMIZE} \
+    --bind \
+    -s STRICT=1 \
+    -s ALLOW_MEMORY_GROWTH=1 \
+    -s ASSERTIONS=0 \
+    -s MODULARIZE=1 \
+    -s FILESYSTEM=0 \
+    -s EXPORT_ES6=1 \
+    -s MALLOC=emmalloc \
+    --std=c++11 \
+    -I node_modules/libyuv/include \
+    -I node_modules/libvpx \
+    -I node_modules/libwebm \
+    -I build-vpx \
+    -I build-webm \
+    -o ./webm-wasm.js \
+    -x c++ \
+    src/webm-wasm.cpp \
+    src/mkvwriter/mymkvwriter.cpp \
+    src/mkvwriter/mymkvstreamwriter.cpp \
+    build-yuv/libyuv.a \
+    build-vpx/libvpx.a \
+    build-webm/libwebm.a
+)
+echo "============================================="
+echo "Compiling wasm bindings done"
+echo "============================================="

--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
   "description": "webm-wasm lets you create webm videos in JavaScript via WebAssembly.",
   "scripts": {
     "build:dockerimage": "docker image inspect -f '.' webmwasm || docker build -t webmwasm .",
-    "build:emscripten": "docker run --rm -v $(pwd):/src -e SKIP_LIBYUV=\"${SKIP_LIBYUV}\" -e SKIP_LIBVPX=\"${SKIP_LIBVPX}\" -e SKIP_LIBWEBM=\"${SKIP_LIBWEBM}\" webmwasm ./build.sh",
-    "build:bundle:worker": "microbundle build -f cjs -o dist/webm-worker.js src/worker/webm-worker.js",
+    "build:emscLibs": "docker run --rm -v $(pwd):/src -e SKIP_LIBYUV=\"${SKIP_LIBYUV}\" -e SKIP_LIBVPX=\"${SKIP_LIBVPX}\" -e SKIP_LIBWEBM=\"${SKIP_LIBWEBM}\" webmwasm ./build.sh",
+    "build:emscCode": "docker run -v $(pwd):/src webmwasm ./emcc.sh && mkdir -p dist && mv webm-wasm.{js,wasm} dist",
+    "build:emscripten": "npm run emscLibs && npm run emscCode",
+    "build:bundle:worker": "microbundle build -f cjs --no-compress -o dist/webm-worker.js src/worker/webm-worker.js",
     "build:bundle:transformstreamworker": "microbundle build -f cjs -o dist/webm-transformstreamworker.js src/worker/webm-transformstreamworker.js",
     "build:bundle": "npm run build:bundle:worker && npm run build:bundle:transformstreamworker",
     "build": "npm run build:dockerimage && npm run build:emscripten && npm run build:bundle",


### PR DESCRIPTION
Splitting build scripts so that the libvpx library and other dependencies don't have to be rebuilt every time the emcc command is ran to generate the wasm.
 
- emcc.sh
- new package.json scripts